### PR TITLE
fix typo + faster is_sorted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ rand = "0.8"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[bench]]
+harness = false
+name = "is_sorted"

--- a/benches/is_sorted.rs
+++ b/benches/is_sorted.rs
@@ -1,0 +1,48 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use indexsort::IndexSort;
+
+fn is_sorted_small(c: &mut Criterion) {
+	let mut data = (0..10_000)
+		.map(|_| rand::random::<isize>())
+		.collect::<Vec<_>>();
+	IndexSort::sort(&mut data);
+
+	c.bench_function("is_sorted(10k)", |b| {
+		b.iter(|| {
+			assert!(IndexSort::is_sorted(&data));
+		});
+	});
+
+	c.bench_function("is_sorted2(10k)", |b| {
+		b.iter(|| {
+			assert!(IndexSort::is_sorted2(&data));
+		});
+	});
+}
+
+fn is_sorted_large(c: &mut Criterion) {
+	let mut data = (0..100_000_000)
+		.map(|_| rand::random::<isize>())
+		.collect::<Vec<_>>();
+	IndexSort::sort(&mut data);
+
+	c.bench_function("is_sorted(100m)", |b| {
+		b.iter(|| {
+			assert!(IndexSort::is_sorted(&data));
+		});
+	});
+
+	c.bench_function("is_sorted2(100m)", |b| {
+		b.iter(|| {
+			assert!(IndexSort::is_sorted2(&data));
+		});
+	});
+}
+
+criterion_group!(
+    benches,
+    is_sorted_small,
+	is_sorted_large
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@ struct LessSwap<'a, T, L> {
     less: L,
 }
 
-struct InmutableLessSwap<'a, T, L> {
+struct ImmutableLessSwap<'a, T, L> {
     data: &'a [T],
     less: L,
 }
 
-impl<'a, T, L> IndexSort for InmutableLessSwap<'a, T, L>
+impl<'a, T, L> IndexSort for ImmutableLessSwap<'a, T, L>
 where
     L: Fn(usize, usize) -> bool,
 {
@@ -88,7 +88,7 @@ pub trait SliceSortExt {
     where
         L: Fn(usize, usize) -> bool,
     {
-        let sorter = InmutableLessSwap { data, less };
+        let sorter = ImmutableLessSwap { data, less };
         sorter.is_sorted()
     }
 }
@@ -128,7 +128,7 @@ pub fn slice_is_sorted<T, L>(data: &[T], less: L) -> bool
 where
     L: Fn(usize, usize) -> bool,
 {
-    let sorter = InmutableLessSwap { data, less };
+    let sorter = ImmutableLessSwap { data, less };
     sorter.is_sorted()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,25 @@ pub trait IndexSort {
         true
     }
 
+    /// Returns whether the data is sorted. O(N/2) version
+    #[inline]
+    fn is_sorted2(&self) -> bool {
+        let len = self.len();
+
+        let n = (len >> 1) + 1;
+        for i in 1..n {
+            if self.less(i, i - 1) {
+                return false;
+            }
+            let tail_off = len - i;
+
+            if self.less(tail_off, tail_off - 1) {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Returns whether the data is sorted in reverse order.
     #[inline]
     fn is_reverse_sorted(&self) -> bool {

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -40,6 +40,29 @@ fn test_sort_int_slice() {
 }
 
 #[test]
+fn test_is_sort_2() {
+    let mut data = INTS.to_vec();
+    IndexSort::sort(&mut data);
+    assert!(IndexSort::is_sorted2(&data));
+
+    let mut data = INTS.to_vec().repeat(7);
+    IndexSort::sort_stable(&mut data);
+    assert!(IndexSort::is_sorted2(&data));
+
+    let mut data = (0..10000)
+        .map(|_| rand::random::<isize>())
+        .collect::<Vec<_>>();
+    IndexSort::sort_stable(&mut data);
+    assert!(IndexSort::is_sorted2(&data));
+    
+    let mut data = (0..1000000)
+        .map(|_| rand::random::<isize>())
+        .collect::<Vec<_>>();
+    IndexSort::sort_stable(&mut data);
+    assert!(IndexSort::is_sorted2(&data));
+}
+
+#[test]
 fn test_sort_f64_slice() {
     let mut data = FLOATS.to_vec();
     IndexSort::sort(&mut data);

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -39,6 +39,16 @@ fn test_sort_int_slice() {
     assert!(IndexSort::is_sorted(&data));
 }
 
+macro_rules! try_swap {
+    ($vec:ident, $a:literal, $b:literal, $block:block) => {
+        {
+            $vec.swap($a, $b);
+            $block;
+            $vec.swap($a, $b);
+        }
+    };
+}
+
 #[test]
 fn test_is_sort_2() {
     let mut data = INTS.to_vec();
@@ -60,6 +70,13 @@ fn test_is_sort_2() {
         .collect::<Vec<_>>();
     IndexSort::sort_stable(&mut data);
     assert!(IndexSort::is_sorted2(&data));
+
+    let mut data = vec![0, 1, 2, 3, 4, 5];
+    assert!(IndexSort::is_sorted2(&data));
+    try_swap!(data, 0, 1, {assert!(!IndexSort::is_sorted2(&data))});
+    try_swap!(data, 1, 2, {assert!(!IndexSort::is_sorted2(&data))});
+    try_swap!(data, 2, 3, {assert!(!IndexSort::is_sorted2(&data))});
+    try_swap!(data, 4, 5, {assert!(!IndexSort::is_sorted2(&data))});
 }
 
 #[test]


### PR DESCRIPTION
+ Fix typo : `InmutableLessSwap` -> `ImmutableLessSwap`
+ `IndexSort::is_sorted2()`
   This is an improved version of `IndexSort::is_sorted`.
   I didn't replace internal function with `is_sorted2` because I'm not sure about its behavior, 
   If you want to replace original function with this new implementation, do it manually (or tell me to do so).
 
   worst case scenario: O(N/2) 

   This implementation compare element at head and tail in same loop (visualize below)
   ```
   len = 13
   iter 1: less(1, 0), less(12, 11)
   iter 2: less(2, 1), less(11, 10)
   iter 3: less(3, 2), less(10, 9)
   iter 4: less(4, 3), less(9, 8)
   iter 5: less(5, 4), less(8, 7)
   iter 6: less(6, 5), less(7, 6)
   ```
   > if len is even it will compare middle element twice (`less(7, 6)` will run twice if `len=14`)

   result from `cargo bench`
   ```
    is_sorted(10k)          time:   [8.9054 µs 8.9057 µs 8.9059 µs]
    1 (1.00%) low severe
    2 (2.00%) high mild
    2 (2.00%) high severe

    is_sorted2(10k)         time:   [6.1242 µs 6.1258 µs 6.1283 µs]
    1 (1.00%) low severe
    2 (2.00%) low mild
    1 (1.00%) high mild
    8 (8.00%) high severe

    is_sorted(100m)         time:   [115.44 ms 117.43 ms 119.60 ms]
    1 (1.00%) high mild

    is_sorted2(100m)        time:   [84.528 ms 84.769 ms 84.978 ms]
    5 (5.00%) low severe
    3 (3.00%) low mild
    1 (1.00%) high mild
   ```